### PR TITLE
Show invalid message when invalid postal code is entered in find command

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -20,6 +20,8 @@ public class Messages {
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_NO_MATCH = "No match found!";
     public static final String MESSAGE_INVALID_POSTAL = "This postal code is invalid.";
+    public static final String MESSAGE_INVALID_POSTAL_CODE =
+            "This postal code is invalid. Find by postal code must start with 'S', followed by up to 6 digits.";
 
 
     /**

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_POSTAL_CODE;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,6 +39,9 @@ public class FindCommandParser implements Parser<FindCommand> {
             if (!isValidKeyword(keyword)) {
                 throw new ParseException(
                         String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+            }
+            if (keyword.startsWith("S") && !isPostalCode(keyword)) {
+                throw new ParseException(MESSAGE_INVALID_POSTAL_CODE);
             }
         }
 


### PR DESCRIPTION
Original code recognised `find S12a` as an address. It should now recognise `S12a` as an invalid postal code and shows appropriate error message.